### PR TITLE
Transforming the 13digit timestamp to the 10digit one

### DIFF
--- a/server/lib/wechat_js.js
+++ b/server/lib/wechat_js.js
@@ -56,7 +56,7 @@ WechatJs = (function buildAPI(){
     },
     generateJsConfig: function( url ){
       var noncestr = ( new Mongo.ObjectID() )._str;
-      var timestamp = Date.now();
+      var timestamp = Math.floor(Date.now()/1000);
       var ticket = WechatJsTickets.getCurrentTicket();
       var signature = this.generateTicketSignature( noncestr, ticket, timestamp, url );
       return {


### PR DESCRIPTION
Wechat JS SDK is accepting only 10 digits timestamps (on seconds). The date.now() used is generating a timestamp on 13 digits (in milliseconds) so it does not generate the right signature. Tested with http://mp.weixin.qq.com/debug/cgi-bin/sandbox?t=jsapisign.

Thanks for that great plugin btw!
