### PR TITLE
bump jsweixin from 1.0.0 to 1.1.0 to use iBeacon features

### DIFF
--- a/client/templates/app.html
+++ b/client/templates/app.html
@@ -1,3 +1,3 @@
 <head>
-  <script src="http://res.wx.qq.com/open/js/jweixin-1.0.0.js"></script>
+  <script src="http://res.wx.qq.com/open/js/jweixin-1.1.0.js"></script>
 </head>


### PR DESCRIPTION
According to the [official document](http://mp.weixin.qq.com/wiki/7/aaa137b55fb2e0456bf8dd9148dd613f.html#.E6.AD.A5.E9.AA.A4.E4.BA.8C.EF.BC.9A.E5.BC.95.E5.85.A5JS.E6.96.87.E4.BB.B6), js lib 1.1.0 is required for iBeacon features.
